### PR TITLE
removed default input options

### DIFF
--- a/Application/Certificationy.php
+++ b/Application/Certificationy.php
@@ -11,8 +11,11 @@
 namespace Certificationy\Application;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Certificationy\Command\StartCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Class Certificationy
@@ -50,5 +53,22 @@ class Certificationy extends Application
         $inputDefinition->setArguments();
 
         return $inputDefinition;
+    }
+    
+    /**
+     * Gets the default input definition.
+     *
+     * @return InputDefinition An InputDefinition instance
+     */
+    protected function getDefaultInputDefinition()
+    {
+        return new InputDefinition(array(
+            new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
+
+            new InputOption('--help',           '-h', InputOption::VALUE_NONE, 'Display this help message.'),
+            new InputOption('--version',        '-V', InputOption::VALUE_NONE, 'Display this application version.'),
+            new InputOption('--ansi',           '',   InputOption::VALUE_NONE, 'Force ANSI output.'),
+            new InputOption('--no-ansi',        '',   InputOption::VALUE_NONE, 'Disable ANSI output.'),
+        ));
     }
 }


### PR DESCRIPTION
Removed the default --input options because they dont gives any meaning

The following options are removed
- --quiet
- --verbose
- --no-interaction
