### PR TITLE
Added key check and replaced duplicate answer

### DIFF
--- a/Certification/Loader.php
+++ b/Certification/Loader.php
@@ -44,7 +44,7 @@ class Loader
             $answers = array();
 
             foreach ($item['answers'] as $dataAnswer) {
-                $answers[] = new Answer($dataAnswer['value'], $dataAnswer['correct']);
+                $answers[] = new Answer($dataAnswer['value'], array_key_exists('correct', $dataAnswer) ? $dataAnswer['correct'] : false);
             }
 
             shuffle($answers);

--- a/data/controllers.yml
+++ b/data/controllers.yml
@@ -20,4 +20,4 @@ questions:
             - {value: Symfony\Bundle\FrameworkBundle\Controller,    correct: true}
             - {value: Symfony\Component\FrameworkBundle\Controller, correct: false}
             - {value: Symfony\Bundle\HttpBundle\Controller,         correct: false}
-            - {value: Symfony\Component\FrameworkBundle\Controller, correct: false}
+            - {value: Symfony\Component\MvcBundle\Controller,       correct: false}


### PR DESCRIPTION
Hi Vincent,

Just found this great little tool from one of your tweets on the Sonata footer: http://sonata-project.org/get-started. 

I'm liking it and using it as we speak and hit some small obstacles that I've tried to fix with this PR. I'm not sure if you're open to them already, just gimme a shout if it needs some more work.

1) array_key_exists check had to be added because of:

```
% php certificationy.php                                                                                    
Starting a new set of 20 questions
PHP Notice:  Undefined index: correct in /Users/me/git/prive/certificationy/Certification/Loader.php on line 47
PHP Stack trace:
PHP   1. {main}() /Users/me/git/prive/certificationy/certificationy.php:0
PHP   2. Symfony\Component\Console\Application->run() /Users/me/git/prive/certificationy/certificationy.php:18
PHP   3. Symfony\Component\Console\Application->doRun() /Users/me/git/prive/certificationy/vendor/symfony/console/Symfony/Component/Console/Application.php:124
PHP   4. Symfony\Component\Console\Application->doRunCommand() /Users/me/git/prive/certificationy/vendor/symfony/console/Symfony/Component/Console/Application.php:193
PHP   5. Symfony\Component\Console\Command\Command->run() /Users/me/git/prive/certificationy/vendor/symfony/console/Symfony/Component/Console/Application.php:887
PHP   6. Certificationy\Command\StartCommand->execute() /Users/me/git/prive/certificationy/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:252
PHP   7. Certificationy\Certification\Loader::init() /Users/me/git/prive/certificationy/Command/StartCommand.php:52
```

2) The duplicate answer; I'm pretty sure it wasn't your intention (one of them was set to be an 'incorrect' answer), but does my replacement suit the question well enough?

Keep up the great work!
