### PR TITLE
add double qoute

### DIFF
--- a/data/validation.yml
+++ b/data/validation.yml
@@ -10,7 +10,7 @@ questions:
     -
         question: 'Using Validator component, which method is used to validate a value against a constraint?'
         answers:
-            - {value: $validator->validate($object, $constraint),      correct: false}
-            - {value: $validator->validateValue($object, $constraint), correct: true}
-            - {value: $validator->isValid($object, $constraint),       correct: false}
-            - {value: $validator->validation($object, $constraint),    correct: false}
+            - {value: "$validator->validate($object, $constraint)",      correct: false}
+            - {value: "$validator->validateValue($object, $constraint)", correct: true}
+            - {value: "$validator->isValid($object, $constraint)",       correct: false}
+            - {value: "$validator->validation($object, $constraint)",    correct: false}


### PR DESCRIPTION
add double quote to avoid error message undefined index : correct.
reason : Yaml::parse() use comma as separator
