### PR TITLE
A single quote ' must be doubled ''

### DIFF
--- a/data/twig.yml
+++ b/data/twig.yml
@@ -15,7 +15,7 @@ questions:
             - {value: "{{ 'my string'|capitalize }}", correct: false}
             - {value: "{{ 'my string'|big }}",        correct: false}
     -
-        question: 'Using Twig, syntax {% block example '' %} is equivalent to {% block example %}{% endblock %}'
+        question: 'Using Twig, syntax {% block example '''' %} is equivalent to {% block example %}{% endblock %}'
         answers:
             - {value: Yes, correct: true}
             - {value: No,  correct: false}


### PR DESCRIPTION
As a reference you may check the Symfony documentation related to YAML component
http://symfony.com/doc/current/components/yaml/yaml_format.html
